### PR TITLE
Initialize Reporter Block at the start of recognition

### DIFF
--- a/scratch-vm/src/extensions/scratch3_speech2scratch/index.js
+++ b/scratch-vm/src/extensions/scratch3_speech2scratch/index.js
@@ -78,6 +78,7 @@ class Scratch3Speech2Scratch {
         recognition.onresult = (event) => {
             this.speech = event.results[0][0].transcript;
         }
+        this.speech = '';
         recognition.start();
     }
 


### PR DESCRIPTION
「音声認識開始」時に「音声」ブロックを空にするため、`recognition.start()` の直前に`this.speech`を初期化するステップを追加してみました。よろしくお願いします🙏